### PR TITLE
Fix masking

### DIFF
--- a/geedim/download.py
+++ b/geedim/download.py
@@ -52,7 +52,7 @@ supported_dtypes = ['uint8', 'uint16', 'uint32', 'int8', 'int16', 'int32', 'floa
 
 
 class BaseImage:
-    _float_nodata = float('nan')
+    _float_nodata = float('-inf')
     _desc_width = 50
     _default_resampling = ResamplingMethod.near
     _ee_max_tile_size = 32
@@ -984,6 +984,9 @@ class BaseImage:
 
             def download_tile(tile):
                 """Download a tile and write into the destination GeoTIFF."""
+                # Note: due to an Earth Engine bug (https://issuetracker.google.com/issues/350528377), tile_array is
+                # float64 for uint32 and int64 exp_image types.  The tile_array nodata value is as it should be
+                # though, so conversion to the exp_image / GeoTIFF type happens ok below.
                 tile_array = tile.download(session=session, bar=bar)
                 with out_lock:
                     out_ds.write(tile_array, window=tile.window)

--- a/geedim/mask.py
+++ b/geedim/mask.py
@@ -388,6 +388,7 @@ class Sentinel2ClImage(CloudMaskedImage):
         ee.Image
             An Earth Engine image containing *_MASK and CLOUD_DIST bands.
         """
+        # TODO: add warning about post Feb 2022 validity when qa method is used
         mask_method = CloudMaskMethod(mask_method)
 
         def get_cloud_prob(ee_im):

--- a/geedim/tile.py
+++ b/geedim/tile.py
@@ -127,11 +127,6 @@ class Tile:
         with utils.suppress_rio_logs(), env, MemoryFile(gtiff_bytes) as mem_file:
             with mem_file.open() as ds:
                 array = ds.read()
-                if (array.dtype == np.dtype('float32')) or (array.dtype == np.dtype('float64')):
-                    # GEE sets nodata to -inf for float data types, (but does not populate the nodata field).
-                    # rasterio won't allow nodata=-inf, so this is a workaround to change nodata to nan at
-                    # source.
-                    array[np.isinf(array)] = np.nan
         return array
 
     def download(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ readme = 'README.rst'
 requires-python = '>=3.6'
 dependencies = [
     'numpy>=1.19',
-    'rasterio>=1.1',
+    'rasterio>=1.3',
     'click>=8',
     'tqdm>=4.6',
     'earthengine-api>=0.1.2',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,13 +13,16 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
+
 import pathlib
 from typing import Dict, List
 
 import ee
 import pytest
 from click.testing import CliRunner
+
 from geedim import Initialize, MaskedImage
+from geedim.mask import Sentinel2SrClImage
 from geedim.utils import root_path
 
 
@@ -31,31 +34,34 @@ def ee_init():
 
 @pytest.fixture(scope='session')
 def region_25ha() -> Dict:
-    """ A geojson polygon defining a 500x500m region. """
+    """A geojson polygon defining a 500x500m region."""
     return {
         "type": "Polygon",
-        "coordinates":
-            [[[21.6389, -33.4520], [21.6389, -33.4474], [21.6442, -33.4474], [21.6442, -33.4520], [21.6389, -33.4520]]]
+        "coordinates": [
+            [[21.6389, -33.4520], [21.6389, -33.4474], [21.6442, -33.4474], [21.6442, -33.4520], [21.6389, -33.4520]]
+        ],
     }
 
 
 @pytest.fixture(scope='session')
 def region_100ha() -> Dict:
-    """ A geojson polygon defining a 1x1km region. """
+    """A geojson polygon defining a 1x1km region."""
     return {
         "type": "Polygon",
-        "coordinates":
-            [[[21.6374, -33.4547], [21.6374, -33.4455], [21.6480, -33.4455], [21.6480, -33.4547], [21.6374, -33.4547]]]
+        "coordinates": [
+            [[21.6374, -33.4547], [21.6374, -33.4455], [21.6480, -33.4455], [21.6480, -33.4547], [21.6374, -33.4547]]
+        ],
     }
 
 
 @pytest.fixture(scope='session')
 def region_10000ha() -> Dict:
-    """ A geojson polygon defining a 10x10km region. """
+    """A geojson polygon defining a 10x10km region."""
     return {
         "type": "Polygon",
-        "coordinates":
-            [[[21.5893, -33.4964], [21.5893, -33.4038], [21.6960, -33.4038], [21.6960, -33.4964], [21.5893, -33.4964]]]
+        "coordinates": [
+            [[21.5893, -33.4964], [21.5893, -33.4038], [21.6960, -33.4038], [21.6960, -33.4964], [21.5893, -33.4964]]
+        ],
     }
 
 
@@ -66,75 +72,83 @@ def const_image_25ha_file() -> pathlib.Path:
 
 @pytest.fixture(scope='session')
 def l4_image_id() -> str:
-    """ Landsat-4 EE ID for image that covers `region_*ha`, with partial cloud cover only for `region10000ha`.  """
+    """Landsat-4 EE ID for image that covers `region_*ha`, with partial cloud cover only for `region10000ha`."""
     return 'LANDSAT/LT04/C02/T1_L2/LT04_173083_19880310'
 
 
 @pytest.fixture(scope='session')
 def l5_image_id() -> str:
-    """ Landsat-5 EE ID for image that covers `region_*ha` with partial cloud cover.  """
+    """Landsat-5 EE ID for image that covers `region_*ha` with partial cloud cover."""
     return 'LANDSAT/LT05/C02/T1_L2/LT05_173083_20051112'  # 'LANDSAT/LT05/C02/T1_L2/LT05_173083_20070307'
 
 
 @pytest.fixture(scope='session')
 def l7_image_id() -> str:
-    """ Landsat-7 EE ID for image that covers `region_*ha` with partial cloud cover.  """
+    """Landsat-7 EE ID for image that covers `region_*ha` with partial cloud cover."""
     return 'LANDSAT/LE07/C02/T1_L2/LE07_173083_20220119'  # 'LANDSAT/LE07/C02/T1_L2/LE07_173083_20200521'
 
 
 @pytest.fixture(scope='session')
 def l8_image_id() -> str:
-    """ Landsat-8 EE ID for image that covers `region_*ha` with partial cloud cover.  """
+    """Landsat-8 EE ID for image that covers `region_*ha` with partial cloud cover."""
     return 'LANDSAT/LC08/C02/T1_L2/LC08_173083_20180217'  # 'LANDSAT/LC08/C02/T1_L2/LC08_173083_20171113'
 
 
 @pytest.fixture(scope='session')
 def l9_image_id() -> str:
-    """ Landsat-9 EE ID for image that covers `region_*ha` with partial cloud cover. """
+    """Landsat-9 EE ID for image that covers `region_*ha` with partial cloud cover."""
     return 'LANDSAT/LC09/C02/T1_L2/LC09_173083_20220308'  # 'LANDSAT/LC09/C02/T1_L2/LC09_173083_20220103'
 
 
 @pytest.fixture(scope='session')
 def landsat_image_ids(l4_image_id, l5_image_id, l7_image_id, l8_image_id, l9_image_id) -> List[str]:
-    """ Landsat4-9 EE IDs for images that covers `region_*ha` with partial cloud cover. """
+    """Landsat4-9 EE IDs for images that covers `region_*ha` with partial cloud cover."""
     return [l4_image_id, l5_image_id, l7_image_id, l8_image_id, l9_image_id]
 
 
 @pytest.fixture(scope='session')
 def s2_sr_image_id() -> str:
-    """ Sentinel-2 SR EE ID for image that covers `region_*ha` with partial cloud cover. """
+    """Sentinel-2 SR EE ID for image that covers `region_*ha` with partial cloud cover."""
     # 'COPERNICUS/S2/20220107T081229_20220107T083059_T34HEJ'
     return 'COPERNICUS/S2_SR/20211004T080801_20211004T083709_T34HEJ'
 
 
 @pytest.fixture(scope='session')
 def s2_toa_image_id() -> str:
-    """ Sentinel-2 TOA EE ID for image that covers `region_*ha` with partial cloud cover. """
+    """Sentinel-2 TOA EE ID for image that covers `region_*ha` with partial cloud cover."""
     return 'COPERNICUS/S2/20220107T081229_20220107T083059_T34HEJ'
 
 
 @pytest.fixture(scope='session')
 def s2_sr_hm_image_id() -> str:
-    """ Harmonised Sentinel-2 SR EE ID for image that covers `region_*ha` with partial cloud cover. """
+    """Harmonised Sentinel-2 SR EE ID for image that covers `region_*ha` with partial cloud cover."""
     # 'COPERNICUS/S2/20220107T081229_20220107T083059_T34HEJ'
     return 'COPERNICUS/S2_SR_HARMONIZED/20211004T080801_20211004T083709_T34HEJ'
 
 
 @pytest.fixture(scope='session')
+def s2_sr_hm_noqa_image_id() -> str:
+    """Harmonised Sentinel-2 SR EE ID for image with no QA* data, that covers `region_*ha` with partial cloud
+    cover.
+    """
+    return 'COPERNICUS/S2_SR_HARMONIZED/20240426T080609_20240426T083054_T34HEJ'
+
+
+@pytest.fixture(scope='session')
 def s2_toa_hm_image_id() -> str:
-    """ Harmonised Sentinel-2 TOA EE ID for image that covers `region_*ha` with partial cloud cover. """
+    """Harmonised Sentinel-2 TOA EE ID for image that covers `region_*ha` with partial cloud cover."""
     return 'COPERNICUS/S2_HARMONIZED/20220107T081229_20220107T083059_T34HEJ'
 
 
 @pytest.fixture(scope='session')
 def s2_image_ids(s2_sr_image_id, s2_toa_image_id, s2_sr_hm_image_id, s2_toa_hm_image_id) -> List[str]:
-    """ Sentinel-2 TOA/SR EE IDs for images that covers `region_*ha` with partial cloud cover. """
+    """Sentinel-2 TOA/SR EE IDs for images that covers `region_*ha` with partial cloud cover."""
     return [s2_sr_image_id, s2_toa_image_id, s2_sr_hm_image_id, s2_toa_hm_image_id]
 
 
 @pytest.fixture(scope='session')
 def modis_nbar_image_id() -> str:
-    """ Global MODIS NBAR image ID.  WGS84 @ 500m. """
+    """Global MODIS NBAR image ID.  WGS84 @ 500m."""
     return 'MODIS/006/MCD43A4/2022_01_01'
 
 
@@ -149,25 +163,25 @@ def gch_image_id() -> str:
 
 @pytest.fixture(scope='session')
 def s1_sar_image_id() -> str:
-    """ Sentinel-1 SAR GRD EE image ID.  10m. """
+    """Sentinel-1 SAR GRD EE image ID.  10m."""
     return 'COPERNICUS/S1_GRD/S1A_IW_GRDH_1SDV_20220112T171750_20220112T171815_041430_04ED28_0A04'
 
 
 @pytest.fixture(scope='session')
 def gedi_agb_image_id() -> str:
-    """ GEDI aboveground biomass density EE image ID.  1km."""
+    """GEDI aboveground biomass density EE image ID.  1km."""
     return 'LARSE/GEDI/GEDI04_B_002'
 
 
 @pytest.fixture(scope='session')
 def gedi_cth_image_id() -> str:
-    """ GEDI canopy top height EE image ID.  25m."""
+    """GEDI canopy top height EE image ID.  25m."""
     return 'LARSE/GEDI/GEDI02_A_002_MONTHLY/202009_018E_036S'
 
 
 @pytest.fixture(scope='session')
 def landsat_ndvi_image_id() -> str:
-    """ Landsat 8-day NDVI composite EE image iD.  Composite in WGS84 with underlying 30m scale."""
+    """Landsat 8-day NDVI composite EE image iD.  Composite in WGS84 with underlying 30m scale."""
     return 'LANDSAT/LC08/C01/T1_8DAY_NDVI/20211219'
 
 
@@ -175,157 +189,186 @@ def landsat_ndvi_image_id() -> str:
 def generic_image_ids(
     modis_nbar_image_id, gch_image_id, s1_sar_image_id, gedi_agb_image_id, gedi_cth_image_id, landsat_ndvi_image_id
 ) -> List[str]:
-    """ A list of various EE image IDs for non-cloud/shadow masked images. """
+    """A list of various EE image IDs for non-cloud/shadow masked images."""
     return [
-        modis_nbar_image_id, gch_image_id, s1_sar_image_id, gedi_agb_image_id, gedi_cth_image_id, landsat_ndvi_image_id
+        modis_nbar_image_id,
+        gch_image_id,
+        s1_sar_image_id,
+        gedi_agb_image_id,
+        gedi_cth_image_id,
+        landsat_ndvi_image_id,
     ]
 
 
 @pytest.fixture(scope='session')
 def l4_masked_image(l4_image_id) -> MaskedImage:
-    """ Landsat-4 MaskedImage that covers `region_*ha`, with partial cloud cover only for `region10000ha`. """
+    """Landsat-4 MaskedImage that covers `region_*ha`, with partial cloud cover only for `region10000ha`."""
     return MaskedImage.from_id(l4_image_id)
 
 
 @pytest.fixture(scope='session')
 def l5_masked_image(l5_image_id) -> MaskedImage:
-    """ Landsat-5 MaskedImage that covers `region_*ha` with partial cloud cover. """
+    """Landsat-5 MaskedImage that covers `region_*ha` with partial cloud cover."""
     return MaskedImage.from_id(l5_image_id)
 
 
 @pytest.fixture(scope='session')
 def l7_masked_image(l7_image_id) -> MaskedImage:
-    """ Landsat-7 MaskedImage that covers `region_*ha` with partial cloud cover. """
+    """Landsat-7 MaskedImage that covers `region_*ha` with partial cloud cover."""
     return MaskedImage.from_id(l7_image_id)
 
 
 @pytest.fixture(scope='session')
 def l8_masked_image(l8_image_id) -> MaskedImage:
-    """ Landsat-8 MaskedImage that cover `region_*ha` with partial cloud cover. """
+    """Landsat-8 MaskedImage that cover `region_*ha` with partial cloud cover."""
     return MaskedImage.from_id(l8_image_id)
 
 
 @pytest.fixture(scope='session')
 def l9_masked_image(l9_image_id) -> MaskedImage:
-    """ Landsat-9 MaskedImage that covers `region_*ha` with partial cloud cover. """
+    """Landsat-9 MaskedImage that covers `region_*ha` with partial cloud cover."""
     return MaskedImage.from_id(l9_image_id)
 
 
 @pytest.fixture(scope='session')
 def landsat_masked_images(
-    l4_masked_image, l5_masked_image, l7_masked_image, l8_masked_image,
-    l9_masked_image
-) -> List[MaskedImage]: # yapf: disable
-    """ Landsat4-9 MaskedImage's that cover `region_*ha` with partial cloud cover. """
+    l4_masked_image, l5_masked_image, l7_masked_image, l8_masked_image, l9_masked_image
+) -> List[MaskedImage]:  # yapf: disable
+    """Landsat4-9 MaskedImage's that cover `region_*ha` with partial cloud cover."""
     return [l4_masked_image, l5_masked_image, l7_masked_image, l8_masked_image, l9_masked_image]
 
 
 @pytest.fixture(scope='session')
 def s2_sr_masked_image(s2_sr_image_id) -> MaskedImage:
-    """ Sentinel-2 SR MaskedImage that covers `region_*ha` with partial cloud cover. """
+    """Sentinel-2 SR MaskedImage that covers `region_*ha` with partial cloud cover."""
     return MaskedImage.from_id(s2_sr_image_id)
 
 
 @pytest.fixture(scope='session')
 def s2_toa_masked_image(s2_toa_image_id) -> MaskedImage:
-    """ Sentinel-2 TOA MaskedImage that covers `region_*ha` with partial cloud cover. """
+    """Sentinel-2 TOA MaskedImage that covers `region_*ha` with partial cloud cover."""
     return MaskedImage.from_id(s2_toa_image_id)
 
 
 @pytest.fixture(scope='session')
 def s2_sr_hm_masked_image(s2_sr_hm_image_id) -> MaskedImage:
-    """ Harmonised Sentinel-2 SR MaskedImage that covers `region_*ha` with partial cloud cover. """
+    """Harmonised Sentinel-2 SR MaskedImage that covers `region_*ha` with partial cloud cover."""
     return MaskedImage.from_id(s2_sr_hm_image_id)
 
 
 @pytest.fixture(scope='session')
+def s2_sr_hm_nocp_masked_image(s2_sr_hm_image_id) -> MaskedImage:
+    """Harmonised Sentinel-2 SR MaskedImage with no corresponding cloud probability, that covers `region_*ha` with
+    partial cloud cover.
+    """
+    ee_image = ee.Image(s2_sr_hm_image_id)
+    ee_image = ee_image.set('system:index', 'unknown')  # prevent linking to cloud probability
+    return Sentinel2SrClImage(ee_image, mask_method='cloud-prob')
+
+
+@pytest.fixture(scope='session')
+def s2_sr_hm_noqa_masked_image(s2_sr_hm_noqa_image_id) -> MaskedImage:
+    """Harmonised Sentinel-2 SR MaskedImage with empty QA* bands, that covers `region_*ha` with partial cloud cover."""
+    return MaskedImage.from_id(s2_sr_hm_noqa_image_id, mask_method='qa')
+
+
+@pytest.fixture(scope='session')
 def s2_toa_hm_masked_image(s2_toa_hm_image_id) -> MaskedImage:
-    """ Harmonised Sentinel-2 TOA MaskedImage that covers `region_*ha` with partial cloud cover. """
+    """Harmonised Sentinel-2 TOA MaskedImage that covers `region_*ha` with partial cloud cover."""
     return MaskedImage.from_id(s2_toa_hm_image_id)
 
 
 @pytest.fixture(scope='session')
 def s2_masked_images(
     s2_sr_masked_image, s2_toa_masked_image, s2_sr_hm_masked_image, s2_toa_hm_masked_image
-) -> List[MaskedImage]: # yapf: disable
-    """ Sentinel-2 TOA and SR MaskedImage's that cover `region_*ha` with partial cloud cover. """
+) -> List[MaskedImage]:  # yapf: disable
+    """Sentinel-2 TOA and SR MaskedImage's that cover `region_*ha` with partial cloud cover."""
     return [s2_sr_masked_image, s2_toa_masked_image, s2_sr_hm_masked_image, s2_toa_hm_masked_image]
 
 
 @pytest.fixture(scope='session')
 def user_masked_image() -> MaskedImage:
-    """ A MaskedImage instance where the encapsulated image has no fixed projection or ID.  """
+    """A MaskedImage instance where the encapsulated image has no fixed projection or ID."""
     return MaskedImage(ee.Image([1, 2, 3]))
 
 
 @pytest.fixture(scope='session')
 def modis_nbar_masked_image(modis_nbar_image_id) -> MaskedImage:
-    """ MODIS NBAR MaskedImage with global coverage.  """
+    """MODIS NBAR MaskedImage with global coverage."""
     return MaskedImage.from_id(modis_nbar_image_id)
 
 
 @pytest.fixture(scope='session')
 def gch_masked_image(gch_image_id) -> MaskedImage:
-    """ Global Canopy Height (10m) MaskedImage. """
+    """Global Canopy Height (10m) MaskedImage."""
     return MaskedImage.from_id(gch_image_id)
 
 
 @pytest.fixture(scope='session')
 def s1_sar_masked_image(s1_sar_image_id) -> MaskedImage:
-    """ Sentinel-1 SAR GRD MaskedImage.  10m. """
+    """Sentinel-1 SAR GRD MaskedImage.  10m."""
     return MaskedImage.from_id(s1_sar_image_id)
 
 
 @pytest.fixture(scope='session')
 def gedi_agb_masked_image(gedi_agb_image_id) -> MaskedImage:
-    """ GEDI aboveground biomass density MaskedImage.  1km."""
+    """GEDI aboveground biomass density MaskedImage.  1km."""
     return MaskedImage.from_id(gedi_agb_image_id)
 
 
 @pytest.fixture(scope='session')
 def gedi_cth_masked_image(gedi_cth_image_id) -> MaskedImage:
-    """ GEDI canopy top height MaskedImage.  25m."""
+    """GEDI canopy top height MaskedImage.  25m."""
     return MaskedImage.from_id(gedi_cth_image_id)
 
 
 @pytest.fixture(scope='session')
 def landsat_ndvi_masked_image(landsat_ndvi_image_id) -> MaskedImage:
-    """ Landsat 8-day NDVI composite MaskedImage.  Composite in WGS84 with underlying 30m scale."""
+    """Landsat 8-day NDVI composite MaskedImage.  Composite in WGS84 with underlying 30m scale."""
     return MaskedImage.from_id(landsat_ndvi_image_id)
 
 
 @pytest.fixture(scope='session')
 def generic_masked_images(
-    modis_nbar_masked_image, gch_masked_image, s1_sar_masked_image, gedi_agb_masked_image, gedi_cth_masked_image,
-    landsat_ndvi_masked_image
+    modis_nbar_masked_image,
+    gch_masked_image,
+    s1_sar_masked_image,
+    gedi_agb_masked_image,
+    gedi_cth_masked_image,
+    landsat_ndvi_masked_image,
 ) -> List[MaskedImage]:
-    """ A list of various non-cloud/shadow MaskedImage's. """
+    """A list of various non-cloud/shadow MaskedImage's."""
     return [
-        modis_nbar_masked_image, gch_masked_image, s1_sar_masked_image, gedi_agb_masked_image, gedi_cth_masked_image,
-        landsat_ndvi_masked_image
+        modis_nbar_masked_image,
+        gch_masked_image,
+        s1_sar_masked_image,
+        gedi_agb_masked_image,
+        gedi_cth_masked_image,
+        landsat_ndvi_masked_image,
     ]
+
 
 @pytest.fixture
 def runner():
-    """ click runner for command line execution. """
+    """click runner for command line execution."""
     return CliRunner()
 
 
 @pytest.fixture
 def region_25ha_file() -> pathlib.Path:
-    """ Path to region_25ha geojson file. """
+    """Path to region_25ha geojson file."""
     return root_path.joinpath('tests/data/region_25ha.geojson')
 
 
 @pytest.fixture
 def region_100ha_file() -> pathlib.Path:
-    """ Path to region_100ha geojson file. """
+    """Path to region_100ha geojson file."""
     return root_path.joinpath('tests/data/region_100ha.geojson')
 
 
 @pytest.fixture
 def region_10000ha_file() -> pathlib.Path:
-    """ Path to region_10000ha geojson file. """
+    """Path to region_10000ha geojson file."""
     return root_path.joinpath('tests/data/region_10000ha.geojson')
 
 
@@ -343,4 +386,3 @@ def get_image_std(ee_image: ee.Image, region: Dict, std_scale: float):
         reducer='mean', geometry=region, crs=proj.crs(), scale=std_scale, bestEffort=True, maxPixels=1e6
     )
     return mean_std_image.get('TEST').getInfo()
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,11 +127,19 @@ def s2_sr_hm_image_id() -> str:
 
 
 @pytest.fixture(scope='session')
-def s2_sr_hm_noqa_image_id() -> str:
-    """Harmonised Sentinel-2 SR EE ID for image with no QA* data, that covers `region_*ha` with partial cloud
+def s2_sr_hm_qa_mask_image_id() -> str:
+    """Harmonised Sentinel-2 SR EE ID for image with masked QA* data, that covers `region_*ha` with partial cloud
     cover.
     """
     return 'COPERNICUS/S2_SR_HARMONIZED/20240426T080609_20240426T083054_T34HEJ'
+
+
+@pytest.fixture(scope='session')
+def s2_sr_hm_qa_zero_image_id() -> str:
+    """Harmonised Sentinel-2 SR EE ID for image with zero QA* data, that covers `region_*ha` with partial cloud
+    cover.
+    """
+    return 'COPERNICUS/S2_SR_HARMONIZED/20230407T080611_20230407T083613_T34HEJ'
 
 
 @pytest.fixture(scope='session')
@@ -261,15 +269,22 @@ def s2_sr_hm_nocp_masked_image(s2_sr_hm_image_id) -> MaskedImage:
     """Harmonised Sentinel-2 SR MaskedImage with no corresponding cloud probability, that covers `region_*ha` with
     partial cloud cover.
     """
+    # create an image with unknown id to prevent linking to cloud probability
     ee_image = ee.Image(s2_sr_hm_image_id)
-    ee_image = ee_image.set('system:index', 'unknown')  # prevent linking to cloud probability
+    ee_image = ee_image.set('system:index', 'COPERNICUS/S2_HARMONIZED/unknown')
     return Sentinel2SrClImage(ee_image, mask_method='cloud-prob')
 
 
 @pytest.fixture(scope='session')
-def s2_sr_hm_noqa_masked_image(s2_sr_hm_noqa_image_id) -> MaskedImage:
-    """Harmonised Sentinel-2 SR MaskedImage with empty QA* bands, that covers `region_*ha` with partial cloud cover."""
-    return MaskedImage.from_id(s2_sr_hm_noqa_image_id, mask_method='qa')
+def s2_sr_hm_qa_mask_masked_image(s2_sr_hm_qa_mask_image_id: str) -> MaskedImage:
+    """Harmonised Sentinel-2 SR MaskedImage with masked QA* bands, that covers `region_*ha` with partial cloud cover."""
+    return MaskedImage.from_id(s2_sr_hm_qa_mask_image_id, mask_method='qa')
+
+
+@pytest.fixture(scope='session')
+def s2_sr_hm_qa_zero_masked_image(s2_sr_hm_qa_zero_image_id: str) -> MaskedImage:
+    """Harmonised Sentinel-2 SR MaskedImage with zero QA* bands, that covers `region_*ha` with partial cloud cover."""
+    return MaskedImage.from_id(s2_sr_hm_qa_zero_image_id, mask_method='qa')
 
 
 @pytest.fixture(scope='session')

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -13,31 +13,35 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
-import ee
-from pathlib import Path
-from httplib2 import Http
+
 import json
+from pathlib import Path
+
+import ee
 import numpy as np
+import pytest
 import rasterio as rio
+from click.testing import CliRunner
+from httplib2 import Http
+from rasterio.coords import BoundingBox
 from rasterio.crs import CRS
 from rasterio.features import bounds
 from rasterio.warp import transform_geom
-from rasterio.coords import BoundingBox
-from click.testing import CliRunner
-import pytest
+
 import geedim as gd
-from geedim import utils, cli
+from geedim import cli, utils
+from geedim.download import BaseImage
 
 
 @pytest.fixture(scope='session', autouse=True)
 def ee_init():
-    """ Override the ee_init fixture, so that we only initialise as geemap does, below. """
+    """Override the ee_init fixture, so that we only initialise as geemap does, below."""
     return
 
 
 def test_geemap_integration(tmp_path: Path):
-    """ Simulate the geemap download example. """
-    gd.Initialize(opt_url=None, http_transport=Http())    # a replica of geemap Initialize
+    """Simulate the geemap download example."""
+    gd.Initialize(opt_url=None, http_transport=Http())  # a replica of geemap Initialize
     ee_image = ee.ImageCollection("LANDSAT/LC08/C02/T1_TOA").first()
     gd_image = gd.download.BaseImage(ee_image)
     out_file = tmp_path.joinpath('landsat.tif')
@@ -47,27 +51,29 @@ def test_geemap_integration(tmp_path: Path):
 
 
 def test_geeml_integration(tmp_path: Path):
-    """ Test the geeml `user memory limit exceeded` example. """
+    """Test the geeml `user memory limit exceeded` example."""
     gd.Initialize()
     region = {
         'geodesic': False,
         'crs': {'type': 'name', 'properties': {'name': 'EPSG:4326'}},
         'type': 'Polygon',
-        'coordinates': [[
-            [6.030749828407996, 53.66867883985145],
-            [6.114742307473171, 53.66867883985145],
-            [6.114742307473171, 53.76381042843971],
-            [6.030749828407996, 53.76381042843971],
-            [6.030749828407996, 53.66867883985145]
-        ]]
+        'coordinates': [
+            [
+                [6.030749828407996, 53.66867883985145],
+                [6.114742307473171, 53.66867883985145],
+                [6.114742307473171, 53.76381042843971],
+                [6.030749828407996, 53.76381042843971],
+                [6.030749828407996, 53.66867883985145],
+            ]
+        ],
     }  # yapf: disable
 
     ee_image = (
-        ee.ImageCollection('COPERNICUS/S2_SR_HARMONIZED').
-        filterDate('2019-01-01', '2020-01-01').
-        filterBounds(region).
-        select(['B4', 'B3', 'B2', 'B8']).
-        reduce(ee.Reducer.percentile([35]))
+        ee.ImageCollection('COPERNICUS/S2_SR_HARMONIZED')
+        .filterDate('2019-01-01', '2020-01-01')
+        .filterBounds(region)
+        .select(['B4', 'B3', 'B2', 'B8'])
+        .reduce(ee.Reducer.percentile([35]))
     )  # yapf: disable
 
     gd_image = gd.download.BaseImage(ee_image)
@@ -82,7 +88,13 @@ def test_geeml_integration(tmp_path: Path):
 
     # test we can download the image with a max_tile_size of 16 MB
     gd_image.download(
-        out_file, crs='EPSG:4326', region=region, scale=10, dtype='float64', overwrite=True, max_tile_size=16,
+        out_file,
+        crs='EPSG:4326',
+        region=region,
+        scale=10,
+        dtype='float64',
+        overwrite=True,
+        max_tile_size=16,
     )
     assert out_file.exists()
     with rio.open(out_file, 'r') as ds:
@@ -94,14 +106,14 @@ def test_geeml_integration(tmp_path: Path):
         # sometimes the top/bottom bounds of the dataset are swapped, so extract and compare UL and BR corners
         print(f'region_bounds: {region_bounds}')
         print(f'ds.bounds: {ds.bounds}')
-        ds_ul = np.array([min(ds.bounds.left,ds.bounds.right), min(ds.bounds.top,ds.bounds.bottom)])
-        ds_lr = np.array([max(ds.bounds.left,ds.bounds.right), max(ds.bounds.top,ds.bounds.bottom)])
+        ds_ul = np.array([min(ds.bounds.left, ds.bounds.right), min(ds.bounds.top, ds.bounds.bottom)])
+        ds_lr = np.array([max(ds.bounds.left, ds.bounds.right), max(ds.bounds.top, ds.bounds.bottom)])
         assert region_cnrs.min(axis=0) == pytest.approx(ds_ul, abs=1e-3)
         assert region_cnrs.max(axis=0) == pytest.approx(ds_lr, abs=1e-3)
 
 
 def test_cli_asset_export(l8_image_id, region_25ha_file: Path, runner: CliRunner, tmp_path: Path):
-    """  Export a test image to an asset using the CLI. """
+    """Export a test image to an asset using the CLI."""
     # create a randomly named folder to allow parallel tests without overwriting the same asset
     gd.Initialize()
     folder = f'geedim/int_test_asset_export_{np.random.randint(1 << 31)}'
@@ -118,7 +130,7 @@ def test_cli_asset_export(l8_image_id, region_25ha_file: Path, runner: CliRunner
             f'--dtype uint16 --mask --resampling bilinear --wait --type asset'
         )
         result = runner.invoke(cli.cli, cli_str.split())
-        assert (result.exit_code == 0)
+        assert result.exit_code == 0
         assert ee.data.getAsset(test_asset_id) is not None
 
         # download the asset image
@@ -139,13 +151,43 @@ def test_cli_asset_export(l8_image_id, region_25ha_file: Path, runner: CliRunner
     with open(region_25ha_file) as f:
         region = json.load(f)
     with rio.open(download_filename, 'r') as im:
-        im : rio.DatasetReader
+        im: rio.DatasetReader
         exp_region = transform_geom('EPSG:4326', im.crs, region)
         exp_bounds = BoundingBox(*bounds(exp_region))
         assert im.crs == CRS.from_string(crs)
         assert im.transform[0] == scale
         assert im.count > 1
         assert (
-            (im.bounds[0] <= exp_bounds[0]) and (im.bounds[1] <= exp_bounds[1]) and
-            (im.bounds[2] >= exp_bounds[2]) and (im.bounds[3] >= exp_bounds[3])
+            (im.bounds[0] <= exp_bounds[0])
+            and (im.bounds[1] <= exp_bounds[1])
+            and (im.bounds[2] >= exp_bounds[2])
+            and (im.bounds[3] >= exp_bounds[3])
         )
+
+
+@pytest.mark.parametrize('dtype', ['float32', 'float64', 'uint8', 'int8', 'uint16', 'int16', 'uint32', 'int32'])
+def test_ee_geotiff_nodata(dtype: str, l9_image_id: str):
+    """Test the nodata value of the Earth Engine GeoTIFF returned by ``ee.data.computePixels()`` or
+    ``ee.Image.getDownloadUrl()`` equals the geedim expected value (see
+    https://issuetracker.google.com/issues/350528377 for context).
+    """
+    # use geedim to prepare an image for downloading as dtype
+    gd.Initialize()
+    masked_image = gd.MaskedImage.from_id(l9_image_id)
+    shape = (10, 10)
+    exp_image, profile = masked_image._prepare_for_download(shape=shape, dtype=dtype)
+
+    # download a small tile with ee.data.computePixels
+    request = {
+        'expression': exp_image.ee_image,
+        'bandIds': ['SR_B3'],
+        'grid': {'dimensions': {'width': shape[1], 'height': shape[0]}},
+        'fileFormat': 'GEO_TIFF',
+    }
+    im_bytes = ee.data.computePixels(request)
+
+    # test nodata with rasterio
+    with rio.MemoryFile(im_bytes) as mf, mf.open() as ds:
+        assert ds.nodata == profile['nodata']
+        # test the EE dtype is not lower precision compared to expected dtype
+        assert np.promote_types(profile['dtype'], ds.dtypes[0]) == ds.dtypes[0]

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -100,7 +100,7 @@ def test_geeml_integration(tmp_path: Path):
     with rio.open(out_file, 'r') as ds:
         assert ds.count == 4
         assert ds.dtypes[0] == 'float64'
-        assert np.isnan(ds.nodata)
+        assert np.isinf(ds.nodata)
         region_cnrs = np.array(region['coordinates'][0])
         region_bounds = rio.coords.BoundingBox(*region_cnrs.min(axis=0), *region_cnrs.max(axis=0))
         # sometimes the top/bottom bounds of the dataset are swapped, so extract and compare UL and BR corners

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -466,18 +466,15 @@ def test_prepare_for_download(base_image: str, request: pytest.FixtureRequest):
         ('int16', -(2**15)),
         ('uint32', 0),
         ('int32', -(2**31)),
-        ('float32', float('nan')),
-        ('float64', float('nan')),
+        ('float32', float('-inf')),
+        ('float64', float('-inf')),
     ],
 )
 def test_prepare_nodata(user_fix_base_image: BaseImage, region_25ha: Dict, dtype: str, exp_nodata: float):
     """Test BaseImage._prepare_for_download() sets rasterio profile nodata correctly for different dtypes."""
     exp_image, exp_profile = user_fix_base_image._prepare_for_download(region=region_25ha, scale=30, dtype=dtype)
     assert exp_image.dtype == dtype
-    if np.isnan(exp_profile['nodata']):
-        assert np.isnan(exp_nodata)
-    else:
-        assert exp_profile['nodata'] == exp_nodata
+    assert exp_profile['nodata'] == exp_nodata
 
 
 @pytest.mark.parametrize(

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -127,7 +127,6 @@ def _test_export_profile(exp_profile, tgt_profile, transform_shape=False):
         assert exp_profile[key] == tgt_profile[key]
 
     assert utils.rio_crs(exp_profile['crs']) == utils.rio_crs(tgt_profile['crs'])
-
     assert exp_profile['transform'][0] == tgt_profile['transform'][0]
 
     if transform_shape:

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -288,7 +288,7 @@ def test_s2_no_cloud_prob(s2_sr_hm_image_id: str, region_100ha: dict):
     ee_image = ee.Image(s2_sr_hm_image_id)
     ee_image = ee_image.set('system:index', 'unknown')  # prevent linking to cloud probability
     masked_image = Sentinel2SrClImage(ee_image, mask_method='cloud-prob')
-    masked_image._set_region_stats(region_100ha)
+    masked_image._set_region_stats(region_100ha, scale=60)
 
     assert masked_image.properties is not None
     assert masked_image.properties['CLOUDLESS_PORTION'] == pytest.approx(0, abs=1)
@@ -301,7 +301,7 @@ def test_s2_no_qa(s2_sr_hm_image_id: str, region_100ha: dict):
     masked_image = MaskedImage.from_id(
         'COPERNICUS/S2_SR_HARMONIZED/20240426T080609_20240426T083054_T34HEJ', mask_method='qa'
     )
-    masked_image._set_region_stats(region_100ha)
+    masked_image._set_region_stats(region_100ha, scale=60)
 
     assert masked_image.properties is not None
     assert masked_image.properties['CLOUDLESS_PORTION'] == pytest.approx(0, abs=1)

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -13,17 +13,19 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
+
 from typing import Dict
 
 import ee
 import numpy as np
 import pytest
 import rasterio as rio
-from geedim.mask import MaskedImage, get_projection, class_from_id
+
+from geedim.mask import MaskedImage, get_projection, class_from_id, Sentinel2SrClImage
 
 
 def test_class_from_id(landsat_image_ids, s2_sr_image_id, s2_toa_hm_image_id, generic_image_ids):
-    """  Test class_from_id(). """
+    """Test class_from_id()."""
     from geedim.mask import LandsatImage, Sentinel2SrClImage, Sentinel2ToaClImage
 
     assert all([class_from_id(im_id) == LandsatImage for im_id in landsat_image_ids])
@@ -33,33 +35,47 @@ def test_class_from_id(landsat_image_ids, s2_sr_image_id, s2_toa_hm_image_id, ge
 
 
 def test_from_id():
-    """ Test MaskedImage.from_id() sets _id. """
+    """Test MaskedImage.from_id() sets _id."""
     ee_id = 'MODIS/006/MCD43A4/2022_01_01'
     gd_image = MaskedImage.from_id(ee_id)
     assert gd_image._id == ee_id
 
 
 @pytest.mark.parametrize(
-    'masked_image', [
-        'user_masked_image', 'modis_nbar_masked_image', 'gch_masked_image', 's1_sar_masked_image',
-        'gedi_agb_masked_image', 'gedi_cth_masked_image', 'landsat_ndvi_masked_image'
-    ]
+    'masked_image',
+    [
+        'user_masked_image',
+        'modis_nbar_masked_image',
+        'gch_masked_image',
+        's1_sar_masked_image',
+        'gedi_agb_masked_image',
+        'gedi_cth_masked_image',
+        'landsat_ndvi_masked_image',
+    ],
 )
 def test_gen_aux_bands_exist(masked_image: str, request: pytest.FixtureRequest):
-    """ Test the presence of auxiliary band (i.e. FILL_MASK) in generic masked images. """
+    """Test the presence of auxiliary band (i.e. FILL_MASK) in generic masked images."""
     masked_image: MaskedImage = request.getfixturevalue(masked_image)
     band_names = masked_image.ee_image.bandNames().getInfo()
     assert 'FILL_MASK' in band_names
 
 
 @pytest.mark.parametrize(
-    'masked_image', [
-        's2_sr_masked_image', 's2_toa_masked_image', 's2_sr_hm_masked_image', 's2_toa_hm_masked_image',
-        'l9_masked_image', 'l8_masked_image', 'l7_masked_image', 'l5_masked_image', 'l4_masked_image'
-    ]
+    'masked_image',
+    [
+        's2_sr_masked_image',
+        's2_toa_masked_image',
+        's2_sr_hm_masked_image',
+        's2_toa_hm_masked_image',
+        'l9_masked_image',
+        'l8_masked_image',
+        'l7_masked_image',
+        'l5_masked_image',
+        'l4_masked_image',
+    ],
 )
 def test_cloud_mask_aux_bands_exist(masked_image: str, request: pytest.FixtureRequest):
-    """ Test the presence of auxiliary bands in cloud masked images. """
+    """Test the presence of auxiliary bands in cloud masked images."""
     masked_image: MaskedImage = request.getfixturevalue(masked_image)
     band_names = masked_image.ee_image.bandNames().getInfo()
     exp_band_names = ['CLOUD_MASK', 'SHADOW_MASK', 'FILL_MASK', 'CLOUDLESS_MASK', 'CLOUD_DIST']
@@ -68,12 +84,25 @@ def test_cloud_mask_aux_bands_exist(masked_image: str, request: pytest.FixtureRe
 
 
 @pytest.mark.parametrize(
-    'masked_image', [
-        's2_sr_masked_image', 's2_toa_masked_image', 's2_sr_hm_masked_image', 's2_toa_hm_masked_image',
-        'l9_masked_image', 'l8_masked_image', 'l7_masked_image', 'l5_masked_image', 'l4_masked_image',
-        'user_masked_image', 'modis_nbar_masked_image', 'gch_masked_image', 's1_sar_masked_image',
-        'gedi_agb_masked_image', 'gedi_cth_masked_image', 'landsat_ndvi_masked_image'
-    ]
+    'masked_image',
+    [
+        's2_sr_masked_image',
+        's2_toa_masked_image',
+        's2_sr_hm_masked_image',
+        's2_toa_hm_masked_image',
+        'l9_masked_image',
+        'l8_masked_image',
+        'l7_masked_image',
+        'l5_masked_image',
+        'l4_masked_image',
+        'user_masked_image',
+        'modis_nbar_masked_image',
+        'gch_masked_image',
+        's1_sar_masked_image',
+        'gedi_agb_masked_image',
+        'gedi_cth_masked_image',
+        'landsat_ndvi_masked_image',
+    ],
 )
 def test_set_region_stats(masked_image: str, region_100ha, request: pytest.FixtureRequest):
     """
@@ -88,7 +117,7 @@ def test_set_region_stats(masked_image: str, region_100ha, request: pytest.Fixtu
 
 @pytest.mark.parametrize('image_id', ['l9_image_id', 'l8_image_id', 'l7_image_id', 'l5_image_id', 'l4_image_id'])
 def test_landsat_cloudless_portion(image_id: str, request: pytest.FixtureRequest):
-    """ Test `geedim` CLOUDLESS_PORTION for the whole image against related Landsat CLOUD_COVER property. """
+    """Test `geedim` CLOUDLESS_PORTION for the whole image against related Landsat CLOUD_COVER property."""
     image_id: MaskedImage = request.getfixturevalue(image_id)
     masked_image = MaskedImage.from_id(image_id, mask_shadows=False, mask_cirrus=False)
     masked_image._set_region_stats()
@@ -101,7 +130,7 @@ def test_landsat_cloudless_portion(image_id: str, request: pytest.FixtureRequest
 
 @pytest.mark.parametrize('image_id', ['s2_toa_image_id', 's2_sr_image_id', 's2_toa_hm_image_id', 's2_sr_hm_image_id'])
 def test_s2_cloudless_portion(image_id: str, request: pytest.FixtureRequest):
-    """ Test `geedim` CLOUDLESS_PORTION for the whole image against CLOUDY_PIXEL_PERCENTAGE Sentinel-2 property. """
+    """Test `geedim` CLOUDLESS_PORTION for the whole image against CLOUDY_PIXEL_PERCENTAGE Sentinel-2 property."""
     image_id: str = request.getfixturevalue(image_id)
     masked_image = MaskedImage.from_id(image_id, mask_method='qa', mask_shadows=False, mask_cirrus=False)
     masked_image._set_region_stats()
@@ -113,7 +142,7 @@ def test_s2_cloudless_portion(image_id: str, request: pytest.FixtureRequest):
 
 @pytest.mark.parametrize('image_id', ['l9_image_id'])
 def test_landsat_cloudmask_params(image_id: str, request: pytest.FixtureRequest):
-    """ Test Landsat cloud/shadow masking `mask_shadows` and `mask_cirrus` parameters. """
+    """Test Landsat cloud/shadow masking `mask_shadows` and `mask_cirrus` parameters."""
     image_id: str = request.getfixturevalue(image_id)
     masked_image = MaskedImage.from_id(image_id, mask_shadows=False, mask_cirrus=False)
     masked_image._set_region_stats()
@@ -135,7 +164,7 @@ def test_landsat_cloudmask_params(image_id: str, request: pytest.FixtureRequest)
 
 @pytest.mark.parametrize('image_id', ['s2_sr_image_id', 's2_toa_image_id'])
 def test_s2_cloudmask_mask_shadows(image_id: str, region_10000ha: Dict, request: pytest.FixtureRequest):
-    """ Test S2 cloud/shadow masking `mask_shadows` parameter. """
+    """Test S2 cloud/shadow masking `mask_shadows` parameter."""
     image_id: str = request.getfixturevalue(image_id)
     masked_image = MaskedImage.from_id(image_id, mask_shadows=False)
     masked_image._set_region_stats(region_10000ha)
@@ -150,7 +179,7 @@ def test_s2_cloudmask_mask_shadows(image_id: str, region_10000ha: Dict, request:
 
 @pytest.mark.parametrize('image_id', ['s2_sr_image_id', 's2_toa_image_id'])
 def test_s2_cloudmask_prob(image_id: str, region_10000ha: Dict, request: pytest.FixtureRequest):
-    """ Test S2 cloud/shadow masking `prob` parameter. """
+    """Test S2 cloud/shadow masking `prob` parameter."""
     image_id: str = request.getfixturevalue(image_id)
     masked_image = MaskedImage.from_id(image_id, mask_shadows=True, prob=80)
     masked_image._set_region_stats(region_10000ha)
@@ -159,12 +188,12 @@ def test_s2_cloudmask_prob(image_id: str, region_10000ha: Dict, request: pytest.
     masked_image._set_region_stats(region_10000ha)
     prob40_portion = 100 * masked_image.properties['CLOUDLESS_PORTION'] / masked_image.properties['FILL_PORTION']
     # test there is more cloud (less CLOUDLESS_PORTION) with prob=40 as compared to prob=80
-    assert prob80_portion > prob40_portion
+    assert prob80_portion > prob40_portion > 0
 
 
 @pytest.mark.parametrize('image_id', ['s2_sr_image_id', 's2_toa_image_id'])
 def test_s2_cloudmask_method(image_id: str, region_10000ha: Dict, request: pytest.FixtureRequest):
-    """ Test S2 cloud/shadow masking `mask_method` parameter. """
+    """Test S2 cloud/shadow masking `mask_method` parameter."""
     image_id: str = request.getfixturevalue(image_id)
     masked_image = MaskedImage.from_id(image_id, mask_method='cloud-prob')
     masked_image._set_region_stats(region_10000ha)
@@ -175,11 +204,12 @@ def test_s2_cloudmask_method(image_id: str, region_10000ha: Dict, request: pytes
     # test `mask_method` changes CLOUDLESS_PORTION but not by too much
     assert cloud_prob_portion != qa_portion
     assert cloud_prob_portion == pytest.approx(qa_portion, abs=10)
+    assert (cloud_prob_portion != pytest.approx(0, abs=1)) and (qa_portion != pytest.approx(0, abs=1))
 
 
 @pytest.mark.parametrize('image_id', ['s2_sr_image_id', 's2_toa_image_id'])
 def test_s2_cloudmask_mask_cirrus(image_id: str, region_10000ha: Dict, request: pytest.FixtureRequest):
-    """ Test S2 cloud/shadow masking `mask_cirrus` parameter. """
+    """Test S2 cloud/shadow masking `mask_cirrus` parameter."""
     image_id: str = request.getfixturevalue(image_id)
     masked_image = MaskedImage.from_id(image_id, mask_method='qa', mask_cirrus=False)
     # cloud and shadow free portion
@@ -194,7 +224,7 @@ def test_s2_cloudmask_mask_cirrus(image_id: str, region_10000ha: Dict, request: 
 
 @pytest.mark.parametrize('image_id', ['s2_sr_image_id', 's2_toa_image_id'])
 def test_s2_cloudmask_dark(image_id: str, region_10000ha: Dict, request: pytest.FixtureRequest):
-    """ Test S2 cloud/shadow masking `dark` parameter. """
+    """Test S2 cloud/shadow masking `dark` parameter."""
     image_id: str = request.getfixturevalue(image_id)
     masked_image = MaskedImage.from_id(image_id, dark=0.5)
     masked_image._set_region_stats(region_10000ha)
@@ -209,7 +239,7 @@ def test_s2_cloudmask_dark(image_id: str, region_10000ha: Dict, request: pytest.
 
 @pytest.mark.parametrize('image_id', ['s2_sr_image_id', 's2_toa_image_id'])
 def test_s2_cloudmask_shadow_dist(image_id: str, region_10000ha: Dict, request: pytest.FixtureRequest):
-    """ Test S2 cloud/shadow masking `shadow_dist` parameter. """
+    """Test S2 cloud/shadow masking `shadow_dist` parameter."""
     image_id: str = request.getfixturevalue(image_id)
     masked_image = MaskedImage.from_id(image_id, shadow_dist=200)
     masked_image._set_region_stats(region_10000ha)
@@ -224,12 +254,12 @@ def test_s2_cloudmask_shadow_dist(image_id: str, region_10000ha: Dict, request: 
 
 @pytest.mark.parametrize('image_id', ['s2_sr_image_id', 's2_toa_image_id'])
 def test_s2_cloudmask_cdi_thresh(image_id: str, region_10000ha: Dict, request: pytest.FixtureRequest):
-    """ Test S2 cloud/shadow masking `cdi_thresh` parameter. """
+    """Test S2 cloud/shadow masking `cdi_thresh` parameter."""
     image_id: str = request.getfixturevalue(image_id)
-    masked_image = MaskedImage.from_id(image_id, cdi_thresh=.5)
+    masked_image = MaskedImage.from_id(image_id, cdi_thresh=0.5)
     masked_image._set_region_stats(region_10000ha)
     cdi_pt5_portion = 100 * masked_image.properties['CLOUDLESS_PORTION'] / masked_image.properties['FILL_PORTION']
-    masked_image = MaskedImage.from_id(image_id, cdi_thresh=-.5)
+    masked_image = MaskedImage.from_id(image_id, cdi_thresh=-0.5)
     masked_image._set_region_stats(region_10000ha)
     cdi_negpt5_portion = 100 * masked_image.properties['CLOUDLESS_PORTION'] / masked_image.properties['FILL_PORTION']
     # test that increasing `cdi_thresh` results in an increase in detected cloud and corresponding decrease in
@@ -239,10 +269,10 @@ def test_s2_cloudmask_cdi_thresh(image_id: str, region_10000ha: Dict, request: p
 
 @pytest.mark.parametrize('image_id, max_cloud_dist', [('s2_sr_image_id', 100), ('s2_sr_hm_image_id', 500)])
 def test_s2_clouddist_max(image_id: str, max_cloud_dist: int, region_10000ha: Dict, request: pytest.FixtureRequest):
-    """ Test S2 cloud distance `max_cloud_dist` parameter. """
+    """Test S2 cloud distance `max_cloud_dist` parameter."""
 
     def get_max_cloud_dist(cloud_dist: ee.Image):
-        """ Get the maximum of `cloud_dist` over region_10000ha. """
+        """Get the maximum of `cloud_dist` over region_10000ha."""
         mcd = cloud_dist.reduceRegion(reducer='max', geometry=region_10000ha, bestEffort=True, maxPixels=1e4)
         return mcd.get('CLOUD_DIST').getInfo() * 10
 
@@ -253,8 +283,33 @@ def test_s2_clouddist_max(image_id: str, max_cloud_dist: int, region_10000ha: Di
     assert meas_max_cloud_dist == pytest.approx(max_cloud_dist, rel=0.1)
 
 
+def test_s2_no_cloud_prob(s2_sr_hm_image_id: str, region_100ha: dict):
+    """Test S2 cloud probability masking without corresponding 'COPERNICUS/S2_CLOUD_PROBABILITY' image gives 100% cloud."""
+    ee_image = ee.Image(s2_sr_hm_image_id)
+    ee_image = ee_image.set('system:index', 'unknown')  # prevent linking to cloud probability
+    masked_image = Sentinel2SrClImage(ee_image, mask_method='cloud-prob')
+    masked_image._set_region_stats(region_100ha)
+
+    assert masked_image.properties is not None
+    assert masked_image.properties['CLOUDLESS_PORTION'] == pytest.approx(0, abs=1)
+    assert masked_image.properties['FILL_PORTION'] == pytest.approx(100, abs=1)
+
+
+def test_s2_no_qa(s2_sr_hm_image_id: str, region_100ha: dict):
+    """Test S2 QA masking with empty QA60 band (i.e. all S2 images post Feb 2022) gives 100% cloud."""
+    # 2024 image that fills region_100ha and has some cloud
+    masked_image = MaskedImage.from_id(
+        'COPERNICUS/S2_SR_HARMONIZED/20240426T080609_20240426T083054_T34HEJ', mask_method='qa'
+    )
+    masked_image._set_region_stats(region_100ha)
+
+    assert masked_image.properties is not None
+    assert masked_image.properties['CLOUDLESS_PORTION'] == pytest.approx(0, abs=1)
+    assert masked_image.properties['FILL_PORTION'] == pytest.approx(100, abs=1)
+
+
 def get_mask_stats(masked_image: MaskedImage, region: Dict):
-    """  Get cloud/shadow etc aux band statistics for a given MaskedImage and region. """
+    """Get cloud/shadow etc aux band statistics for a given MaskedImage and region."""
     ee_image = masked_image.ee_image
     pan = ee_image.select([0, 1, 2]).reduce(ee.Reducer.mean())
     cdist = ee_image.select('CLOUD_DIST')
@@ -262,7 +317,7 @@ def get_mask_stats(masked_image: MaskedImage, region: Dict):
     shadow_mask = ee_image.select('SHADOW_MASK')
     cloudless_mask = ee_image.select('CLOUDLESS_MASK')
     pan_cloud = pan.updateMask(cloud_mask).rename('PAN_CLOUD')
-    pan_shadow = pan.mask(shadow_mask).rename('PAN_SHADOW')
+    pan_shadow = pan.updateMask(shadow_mask).rename('PAN_SHADOW')
     pan_cloudless = pan.updateMask(cloudless_mask).rename('PAN_CLOUDLESS')
     cdist_cloud = cdist.updateMask(cloud_mask).rename('CDIST_CLOUD')
     cdist_cloudless = cdist.updateMask(cloudless_mask).rename('CDIST_CLOUDLESS')
@@ -282,31 +337,38 @@ def get_mask_stats(masked_image: MaskedImage, region: Dict):
     'masked_image', ['l9_masked_image', 'l8_masked_image', 'l7_masked_image', 'l5_masked_image', 'l4_masked_image']
 )
 def test_landsat_aux_bands(masked_image: str, region_10000ha: Dict, request: pytest.FixtureRequest):
-    """ Test Landsat auxiliary band values. """
+    """Test Landsat auxiliary band values for sanity."""
     masked_image: MaskedImage = request.getfixturevalue(masked_image)
     stats = get_mask_stats(masked_image, region_10000ha)
+    # cloud is brighter than cloudless
     assert stats['PAN_CLOUD'] > stats['PAN_CLOUDLESS']
+    # cloudless is brighter than shadow
     assert stats['PAN_CLOUDLESS'] > stats['PAN_SHADOW']
+    # cloudless areas have greater distance to cloud than cloudy areas
     assert stats['CDIST_CLOUDLESS'] > stats['CDIST_CLOUD']
 
 
-@pytest.mark.parametrize('masked_image',
-    ['s2_sr_masked_image', 's2_toa_masked_image', 's2_sr_hm_masked_image', 's2_toa_hm_masked_image']
+@pytest.mark.parametrize(
+    'masked_image', ['s2_sr_masked_image', 's2_toa_masked_image', 's2_sr_hm_masked_image', 's2_toa_hm_masked_image']
 )  # yapf: disable
 def test_s2_aux_bands(masked_image: str, region_10000ha: Dict, request: pytest.FixtureRequest):
-    """ Test Sentinel-2 auxiliary band values. """
+    """Test Sentinel-2 auxiliary band values for sanity."""
     masked_image: MaskedImage = request.getfixturevalue(masked_image)
     stats = get_mask_stats(masked_image, region_10000ha)
+    # cloud is brighter than cloudless
     assert stats['PAN_CLOUD'] > stats['PAN_CLOUDLESS']
+    # cloudless is brighter than shadow
     assert stats['PAN_CLOUDLESS'] > stats['PAN_SHADOW']
+    # cloudless areas have greater distance to cloud than cloudy areas
     assert stats['CDIST_CLOUDLESS'] > stats['CDIST_CLOUD']
     proj_scale = get_projection(masked_image.ee_image, min_scale=False).nominalScale().getInfo()
+    # min distance to cloud is pixel size
     assert stats['CDIST_MIN'] * 10 == proj_scale
 
 
 @pytest.mark.parametrize('masked_image', ['s2_sr_masked_image', 'l9_masked_image'])
 def test_mask_clouds(masked_image: str, region_100ha: Dict, tmp_path, request: pytest.FixtureRequest):
-    """ Test MaskedImage.mask_clouds() by downloading and examining dataset masks. """
+    """Test MaskedImage.mask_clouds() by downloading and examining dataset masks."""
     masked_image: MaskedImage = request.getfixturevalue(masked_image)
     filename = tmp_path.joinpath(f'test_image.tif')
     masked_image.mask_clouds()
@@ -324,11 +386,9 @@ def test_mask_clouds(masked_image: str, region_100ha: Dict, tmp_path, request: p
 
 
 def test_skysat_region_stats():
-    """ Test _set_region_stats() works on SKYSAT image with no region. """
+    """Test _set_region_stats() works on SKYSAT image with no region."""
     ee_image = ee.Image('SKYSAT/GEN-A/PUBLIC/ORTHO/RGB/s02_20141004T074858Z')
     masked_image = MaskedImage(ee_image)
     masked_image._set_region_stats()
     assert 'FILL_PORTION' in masked_image.properties
     assert masked_image.properties['FILL_PORTION'] > 0.8
-##
-

--- a/tests/test_tile.py
+++ b/tests/test_tile.py
@@ -74,7 +74,7 @@ def zipped_gtiff_bytes(mock_base_image: BaseImageLike) -> bytes:
             **rio.default_gtiff_profile,
             width=mock_base_image.shape[1],
             height=mock_base_image.shape[0],
-            count=mock_base_image.count
+            count=mock_base_image.count,
         ) as ds:
             ds.write(array)
         with zipfile.ZipFile(zip_buffer, 'a', zipfile.ZIP_DEFLATED, False) as zf:


### PR DESCRIPTION
Fixes
- Generate full cloud/shadow masks for Sentinel-2 images missing relevant cloud data  (Closes #24).
- Use ``-inf`` ``nodata`` for downloaded GeoTIFFs with ``float64`` / ``float32`` data types to work around [350528377](https://issuetracker.google.com/issues/350528377).
- Pin Rasterio >=1.3 for compatibility with``-inf``  ``nodata`` .
